### PR TITLE
Scope /accounts endpoints under /budget/:id

### DIFF
--- a/app/controllers/api/accounts_controller.rb
+++ b/app/controllers/api/accounts_controller.rb
@@ -3,20 +3,23 @@
 module Api
   class AccountsController < ApplicationController
     before_action :authenticate_user!
+    before_action :authorize_budget!
 
     def index
-      accounts = Account::Base.where(account_params)
-
-      render json: Api::AccountSerializer.new(accounts)
+      render json: Api::AccountSerializer.new(available_accounts)
     end
 
     def show
-      account = Account::Base.find(params[:id])
+      account = available_accounts.find(params[:id])
 
       render json: Api::AccountSerializer.new(account)
     end
 
     private
+
+    def available_accounts
+      current_user.budgets.find(params[:budget_id]).accounts
+    end
 
     def account_params
       params.permit(:budget_board_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,19 @@ class ApplicationController < ActionController::API
 
   respond_to :json
 
+  protected
+
+  def authorize_budget!
+    return if available_budgets.exists?(id: params[:budget_id])
+
+    head :unauthorized
+  end
+
   private
+
+  def available_budgets
+    current_user.budgets
+  end
 
   def not_found
     head :not_found

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Budget < ApplicationRecord
+  has_many :accounts, class_name: 'Account::Base'
   has_many :category_groups
   belongs_to :user
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,10 @@ Rails.application.routes.draw do
   namespace :api, constraints: { format: :json } do
     get 'me', to: 'me#show'
 
-    resources :accounts, only: %i[create index show]
-    resources :budgets, only: %i[create index show]
+    resources :budgets, only: %i[create index show] do
+      resources :accounts, only: %i[create index show]
+    end
+
     resources :users, only: %i[create]
   end
 end

--- a/spec/requests/accounts_request_spec.rb
+++ b/spec/requests/accounts_request_spec.rb
@@ -3,66 +3,94 @@
 require 'rails_helper'
 
 describe Api::AccountsController do
-  let(:user) { create(:user) }
+  let(:budget) { create(:budget) }
   let(:headers) do
     { 'Accept': 'application/json' }
   end
 
-  describe 'GET /api/accounts/' do
+  describe 'GET /api/budgets/:id/accounts/' do
     context 'when there is no authorization' do
       it 'returns :unauthorized' do
-        get '/api/accounts', headers: headers
+        get '/api/budgets/:id/accounts', headers: headers
 
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    it 'returns accounts from any type', :aggregate_failures do
-      tracking_account = create(:tracking_account)
-      checking_account = create(:checking_account)
+    context 'when given budget id does not belong to current user' do
+      it 'returns :unauthorized' do
+        other_budget = create(:budget)
+
+        sign_in(budget.user)
+
+        get "/api/budgets/#{other_budget.id}/accounts", headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'returns accounts from any type at given budget', :aggregate_failures do
+      create(:checking_account, budget: create(:budget))
+      tracking_account = create(:tracking_account, budget: budget)
+      checking_account = create(:checking_account, budget: budget)
 
       allow(Api::AccountSerializer).to receive(:new)
 
-      sign_in(user)
+      sign_in(budget.user)
 
-      get '/api/accounts', headers: headers
+      get "/api/budgets/#{budget.id}/accounts", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(Api::AccountSerializer).to(
-        have_received(:new).with([tracking_account, checking_account])
+      expect(Api::AccountSerializer).to have_received(:new).with(
+        [tracking_account, checking_account]
       )
     end
   end
 
-  describe 'GET /api/accounts/:id' do
+  describe 'GET /api/budgets/:id/accounts/:id' do
     context 'when there is no authorization' do
       it 'returns :unauthorized' do
         account = create(:random_account)
 
-        get "/api/accounts/#{account.id}", headers: headers
+        get "/api/budgets/#{account.budget_id}/accounts/#{account.id}",
+            headers: headers
 
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    context 'when given there is not account with given id' do
-      it 'returns :not_found' do
-        sign_in(create(:user))
+    context 'when given budget id does not belong to current user' do
+      it 'returns :unauthorized' do
+        other_budget = create(:budget)
+        account = create(:random_account, budget: other_budget)
 
-        get '/api/accounts/random-uuid', headers: headers
+        sign_in(budget.user)
+
+        get "/api/budgets/#{other_budget.id}/accounts/#{account.id}",
+            headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when there is no account in given budget with given id' do
+      it 'returns :not_found' do
+        sign_in(budget.user)
+
+        get "/api/budgets/#{budget.id}/accounts/random-uuid", headers: headers
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
     it 'returns the account with the specified id', :aggregate_failures do
-      account = create(:random_account)
+      account = create(:random_account, budget: budget)
 
       allow(Api::AccountSerializer).to receive(:new)
 
-      sign_in(user)
+      sign_in(budget.user)
 
-      get "/api/accounts/#{account.id}", headers: headers
+      get "/api/budgets/#{budget.id}/accounts/#{account.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(Api::AccountSerializer).to(


### PR DESCRIPTION
This enhances semantics by coupling accounts to budgets, expliciting that accounts only make sense when attached to a given budget.

**CHANGELOG**
- Add `ApplicationsController#authorize_budget!`
- Rename `/accounts/*` endpoints to `/budgets/:budget_id/accounts/*`
- Update `/accounts/*` endpoints to restrict their searches to accounts related to given `:budget_id` param