### PR TITLE
Add API endpoint to create monthly budget

### DIFF
--- a/app/controllers/api/monthly_budgets_controller.rb
+++ b/app/controllers/api/monthly_budgets_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  class MonthlyBudgetsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :authorize_budget!
+
+    # POST /api/budgets/:budget_id/monthly_budgets/
+    def create
+      monthly_budget = MonthlyBudgets::Create.call(permitted_params)
+
+      render json: MonthlyBudgetSerializer.new(monthly_budget)
+    end
+
+    private
+
+    def permitted_params
+      params.permit(:budgeted, :category_id, :month_id)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::API
   include ActionController::MimeResponds
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from ApplicationError, with: :render_error
 
   respond_to :json
 
@@ -19,6 +20,10 @@ class ApplicationController < ActionController::API
 
   def available_budgets
     current_user.budgets
+  end
+
+  def render_error(error)
+    render json: error.to_h, status: :bad_request
   end
 
   def not_found

--- a/app/errors/monthly_budgets/already_exists.rb
+++ b/app/errors/monthly_budgets/already_exists.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MonthlyBudgets
+  class AlreadyExists < ApplicationError
+    def code
+      'monthly-budgets/already-exists'
+    end
+
+    def message
+      'There category already has a budget for this month'
+    end
+  end
+end

--- a/app/serializers/api/monthly_budget_serializer.rb
+++ b/app/serializers/api/monthly_budget_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  class MonthlyBudgetSerializer < ApplicationSerializer
+    attributes :activity,
+               :budgeted,
+               :category_id,
+               :month_id
+  end
+end

--- a/app/use_cases/monthly_budgets/create.rb
+++ b/app/use_cases/monthly_budgets/create.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MonthlyBudgets
+  class Create < ApplicationUseCase
+    def initialize(params)
+      @params = params
+    end
+
+    def call
+      raise MonthlyBudgets::AlreadyExists if already_exists?
+
+      ::MonthlyBudget.create!(
+        activity: 0,
+        budgeted: params[:budgeted],
+        category_id: params[:category_id],
+        month_id: params[:month_id],
+      )
+    end
+
+    private
+
+    def already_exists?
+      MonthlyBudget.exists?(
+        category_id: params[:category_id],
+        month_id: params[:month_id],
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       resources :categories, only: %i[create index]
       resources :category_groups, only: %i[create index]
       resources :months, only: %i[show], param: :iso_month
+      resources :monthly_budgets, only: %i[create]
       resources :payees, only: %i[index]
       resources :transactions, only: %i[index]
     end

--- a/spec/factories/monthly_budgets.rb
+++ b/spec/factories/monthly_budgets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :monthly_budget do
+    activity { rand(100_000) }
+    budgeted { rand(100_000) }
+    category
+    month
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,3 +33,5 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end
+
+RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/requests/monthly_budgets_request_spec.rb
+++ b/spec/requests/monthly_budgets_request_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::MonthlyBudgetsController do
+  let(:budget) { create(:budget) }
+  let(:headers) do
+    { 'Accept': 'application/json' }
+  end
+  let(:params) do
+    {
+      budgeted: 0,
+      category_id: create(:category).id,
+      month_id: create(:month).id,
+    }
+  end
+
+  describe 'GET /api/budgets/:id/monthly_budgets' do
+    context 'when there is no authorization' do
+      it 'returns :unauthorized' do
+        post "/api/budgets/#{budget.id}/monthly_budgets",
+             headers: headers,
+             params: params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when given budget id does not belong to current user' do
+      it 'returns :unauthorized' do
+        other_budget = create(:budget)
+
+        sign_in(budget.user)
+
+        post "/api/budgets/#{other_budget.id}/monthly_budgets",
+             headers: headers,
+             params: params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'creates a new monthly budget' do
+      sign_in(budget.user)
+
+      expect do
+        post "/api/budgets/#{budget.id}/monthly_budgets",
+             headers: headers,
+             params: params
+      end.to change { MonthlyBudget.count }.by(1)
+    end
+
+    it 'serializes the newly-created monthly budget' do
+      sign_in(budget.user)
+
+      allow(Api::MonthlyBudgetSerializer).to receive(:new)
+
+      post "/api/budgets/#{budget.id}/monthly_budgets",
+           headers: headers,
+           params: params
+
+      expect(Api::MonthlyBudgetSerializer).to(
+        have_received(:new).with(MonthlyBudget.last),
+      )
+    end
+  end
+end

--- a/spec/serializers/api/monthly_budget_serializer_spec.rb
+++ b/spec/serializers/api/monthly_budget_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::MonthlyBudgetSerializer do
+  it 'serializes using json api' do
+    monthly_budget = create(:monthly_budget)
+
+    result = described_class.new(monthly_budget).serializable_hash
+
+    expect(result).to eq(
+      data: {
+        id: monthly_budget.id,
+        type: :monthly_budget,
+        attributes: {
+          activity: monthly_budget.activity,
+          budgeted: monthly_budget.budgeted,
+          category_id: monthly_budget.category_id,
+          month_id: monthly_budget.month_id,
+        },
+      },
+    )
+  end
+end

--- a/spec/use_cases/monthly_budgets/create_spec.rb
+++ b/spec/use_cases/monthly_budgets/create_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MonthlyBudgets::Create do
+  let(:params) do
+    {
+      budgeted: 0,
+      category_id: create(:category).id,
+      month_id: create(:month).id,
+    }
+  end
+
+  it 'creates a new monthly budget' do
+    month = described_class.call(params)
+
+    expect(month).to have_attributes(
+      **params,
+      activity: 0,
+    )
+  end
+
+  context 'when already exists a monthly budget on this month and category' do
+    it 'raises MonthlyBudgets::AlreadyExists' do
+      create(:monthly_budget,
+             category_id: params[:category_id],
+             month_id: params[:month_id])
+
+      expect do
+        described_class.call(params)
+      end.to raise_error(MonthlyBudgets::AlreadyExists)
+    end
+
+    it 'does not create a new month' do
+      create(:monthly_budget,
+             category_id: params[:category_id],
+             month_id: params[:month_id])
+
+      expect do
+        described_class.call(params)
+      end.to(
+        raise_error(MonthlyBudgets::AlreadyExists).and(
+          not_change { MonthlyBudget.count },
+        ),
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Introduce an application-level rescue to render a handlable error whenever one is raised
- Implement endpoint to create a new monthly budget
- Implement use case that handles monthly budget creation or raises error whenever validation fails