### PR TITLE
Allow creating transactions on API

### DIFF
--- a/.github/workflows/budget-pipe.yml
+++ b/.github/workflows/budget-pipe.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache bundle
-        uses: ruby/setup-ruby@v1.63.0
+        uses: ruby/setup-ruby@v1.70.1
         with:
           bundler-cache: true
       - name: Creating DB
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache bundle
-        uses: ruby/setup-ruby@v1.63.0
+        uses: ruby/setup-ruby@v1.70.1
         with:
           bundler-cache: true
       - name: Running rubocop

--- a/app/controllers/api/payees_controller.rb
+++ b/app/controllers/api/payees_controller.rb
@@ -5,6 +5,7 @@ module Api
     before_action :authenticate_user!
     before_action :authorize_budget!
 
+    # GET /budgets/:id/payees
     def index
       render json: PayeeSerializer.new(available_payees)
     end

--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  class TransactionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :authorize_budget!
+
+    def create
+      transaction = Transactions::Register.call(create_params)
+
+      render json: Api::TransactionSerializer.new(
+        transaction,
+        include: %i[monthly_budget origin payee],
+      )
+    end
+
+    private
+
+    def create_params
+      params.permit(
+        :amount, :budget_id, :cleared_at, :category_id,
+        :memo, :origin_id, :outflow, :payee_name, :reference_at,
+      )
+    end
+  end
+end

--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -19,7 +19,7 @@ module Api
     def create_params
       params.permit(
         :amount, :budget_id, :cleared_at, :category_id,
-        :memo, :origin_id, :outflow, :payee_name, :reference_at,
+        :memo, :origin_id, :outflow, :payee_name, :reference_at
       )
     end
   end

--- a/app/serializers/api/transaction_serializer.rb
+++ b/app/serializers/api/transaction_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  class TransactionSerializer < ApplicationSerializer
+    attributes :amount,
+               :cleared_at,
+               :destination_id,
+               :memo,
+               :monthly_budget_id,
+               :origin_id,
+               :payee_id,
+               :reference_at
+
+    belongs_to :monthly_budget
+    belongs_to :payee
+    belongs_to :origin, serializer: AccountSerializer
+  end
+end

--- a/app/services/months/add_activity.rb
+++ b/app/services/months/add_activity.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Months
+  class AddActivity < ApplicationService
+    def initialize(amount:, budget_id:, category_id:, iso_month:)
+      @amount = amount
+      @category_id = category_id
+      @budget_id = budget_id
+      @iso_month = iso_month
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        find_or_create_month
+        find_or_create_monthly_budget
+        update_activity
+        update_month
+        month
+      end
+    end
+
+    private
+
+    attr_accessor :month, :monthly_budget
+
+    def find_or_create_month
+      @month = Months::FetchOrCreate.call(
+        budget_id: @budget_id,
+        iso_month: @iso_month,
+      )
+    end
+
+    def find_or_create_monthly_budget
+      @monthly_budget = existing_monthly_budget || MonthlyBudgets::Create.call(
+        budgeted: 0,
+        category_id: @category_id,
+        month_id: month.id,
+      )
+    end
+
+    def update_activity
+      monthly_budget.update!(
+        activity: monthly_budget.activity + @amount,
+      )
+    end
+
+    def update_month
+      month.update!(
+        activity: month.activity + @amount,
+      )
+    end
+
+    def existing_monthly_budget
+      month.monthly_budgets.find_by(category_id: @category_id)
+    end
+  end
+end

--- a/app/services/months/add_income.rb
+++ b/app/services/months/add_income.rb
@@ -12,24 +12,25 @@ module Months
       ActiveRecord::Base.transaction do
         find_or_create_month
         update_income
+        month
       end
     end
 
     private
 
-    attr_accessor :amount, :budget_id, :iso_month
+    attr_accessor :month
 
     def find_or_create_month
       @month = Month.find_or_create_by!(
-        budget_id: budget_id,
-        iso_month: iso_month,
+        budget_id: @budget_id,
+        iso_month: @iso_month,
       )
     end
 
     def update_income
       @month.update(
-        income: @month.income + amount,
-        to_be_budgeted: @month.to_be_budgeted + amount,
+        income: month.income + @amount,
+        to_be_budgeted: month.to_be_budgeted + @amount,
       )
     end
   end

--- a/app/use_cases/accounts/create_with_starting_balance.rb
+++ b/app/use_cases/accounts/create_with_starting_balance.rb
@@ -65,7 +65,7 @@ module Accounts
       Months::AddIncome.call(
         amount: initial_balance,
         budget_id: params[:budget_id],
-        iso_month: IsoMonth.of(Date.current)
+        iso_month: IsoMonth.of(Date.current),
       )
     end
   end

--- a/app/use_cases/accounts/create_with_starting_balance.rb
+++ b/app/use_cases/accounts/create_with_starting_balance.rb
@@ -65,7 +65,7 @@ module Accounts
       Months::AddIncome.call(
         amount: initial_balance,
         budget_id: params[:budget_id],
-        iso_month: Date.current.strftime('%Y-%m'),
+        iso_month: IsoMonth.of(Date.current)
       )
     end
   end

--- a/app/use_cases/transactions/register.rb
+++ b/app/use_cases/transactions/register.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Transactions
+  class Register < ApplicationUseCase
+    def initialize(params)
+      @params = params
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        update_month
+        create_transaction
+        update_account_balance
+
+        # INFO: Needed to fetch relationships updated in other classes
+        transaction.reload
+      end
+    end
+
+    private
+
+    attr_accessor :month, :transaction
+
+    def create_transaction
+      @transaction = Transaction.create!(
+        amount: signed_amount,
+        cleared_at: params[:cleared_at],
+        origin_id: params[:origin_id],
+        outflow: params[:outflow],
+        payee: payee,
+        memo: params[:memo],
+        monthly_budget: monthly_budget,
+        reference_at: params[:reference_at],
+      )
+    end
+
+    def update_month
+      if income?
+        add_income
+      else
+        add_activity
+      end
+    end
+
+    def update_account_balance
+      ::Accounts::UpdateBalance.call(
+        account: origin_account,
+        transaction: transaction,
+      )
+    end
+
+    def add_income
+      @month = Months::AddIncome.call(
+        amount: params[:amount],
+        budget_id: params[:budget_id],
+        iso_month: IsoMonth.of(params[:reference_at]),
+      )
+    end
+
+    def add_activity
+      @month = Months::AddActivity.call(
+        amount: params[:amount],
+        budget_id: params[:budget_id],
+        category_id: params[:category_id],
+        iso_month: IsoMonth.of(params[:reference_at]),
+      )
+    end
+
+    def income?
+      params[:category_id].blank?
+    end
+
+    def signed_amount
+      return params[:amount] unless params[:outflow]
+
+      -params[:amount]
+    end
+
+    def payee
+      @payee ||= Payee.find_or_create_by!(
+        budget_id: params[:budget_id],
+        name: params[:payee_name],
+      )
+    end
+
+    def monthly_budget
+      @monthly_budget ||= month.monthly_budgets.find_by(
+        category_id: params[:category_id],
+      )
+    end
+
+    def origin_account
+      @origin_account ||= ::Account::Base.find(params[:origin_id])
+    end
+  end
+end

--- a/app/values/iso_month.rb
+++ b/app/values/iso_month.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class IsoMonth
+  def self.of(date)
+    if date.is_a?(String)
+      Date.parse(date).strftime('%Y-%m')
+    else
+      date.strftime('%Y-%m')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       resources :months, only: %i[show], param: :iso_month
       resources :monthly_budgets, only: %i[create index update]
       resources :payees, only: %i[index]
-      resources :transactions, only: %i[index]
+      resources :transactions, only: %i[create index]
     end
 
     resources :users, only: %i[create]

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -4,5 +4,17 @@ FactoryBot.define do
   factory :category do
     category_group
     name { Faker::Creature::Dog.name }
+
+    trait :with_budget do
+      transient do
+        budget { create(:budget) }
+      end
+
+      after(:create) do |category, evaluator|
+        category.category_group.update!(
+          budget: evaluator.budget
+        )
+      end
+    end
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
       after(:create) do |category, evaluator|
         category.category_group.update!(
-          budget: evaluator.budget
+          budget: evaluator.budget,
         )
       end
     end

--- a/spec/factories/months.rb
+++ b/spec/factories/months.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :month do
     iso_month do
-      Faker::Date.between(from: 2.years.ago, to: Date.today).strftime('%Y-%m')
+      IsoMonth.of(Faker::Date.between(from: 2.years.ago, to: Date.today))
     end
     activity { rand(100_000) }
     budgeted { rand(100_000) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ RSpec.configure do |config|
     config.include Devise::Test::IntegrationHelpers, type: :request
   end
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!

--- a/spec/serializers/api/transaction_serializer_spec.rb
+++ b/spec/serializers/api/transaction_serializer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::TransactionSerializer do
+  it 'serializes using json api' do
+    transaction = create(:transaction)
+
+    result = described_class.new(transaction).serializable_hash
+
+    expect(result).to eq(
+      data: {
+        id: transaction.id,
+        type: :transaction,
+        attributes: {
+          amount: transaction.amount,
+          cleared_at: transaction.cleared_at,
+          destination_id: transaction.destination_id,
+          memo: transaction.memo,
+          monthly_budget_id: transaction.monthly_budget_id,
+          origin_id: transaction.origin_id,
+          payee_id: transaction.payee_id,
+          reference_at: transaction.reference_at,
+        },
+        relationships: {
+          monthly_budget: {
+            data: nil,
+          },
+          origin: {
+            data: {
+              id: transaction.origin_id,
+              type: :account,
+            },
+          },
+          payee: {
+            data: {
+              id: transaction.payee_id,
+              type: :payee,
+            },
+          },
+        },
+      },
+    )
+  end
+end

--- a/spec/services/accounts/create_spec.rb
+++ b/spec/services/accounts/create_spec.rb
@@ -28,4 +28,18 @@ describe Accounts::Create do
       end.to raise_error { Accounts::InvalidTypeError.new }
     end
   end
+
+  context 'when there is an account with same type and name' do
+    it 'raises DuplicateError' do
+      create(:random_account,
+             :with_type,
+             type: type,
+             budget_id: budget.id,
+             name: name)
+
+      expect do
+        described_class.call(budget_id: budget.id, name: name, type: type)
+      end.to raise_error { Accounts::DuplicateError.new }
+    end
+  end
 end

--- a/spec/services/months/add_activity_spec.rb
+++ b/spec/services/months/add_activity_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Months::AddActivity do
+  let(:budget_id) { create(:budget).id }
+  let(:iso_month) { IsoMonth.of(Time.current) }
+  let(:amount) { rand(10_000) }
+  let(:category) { create(:category) }
+
+  it "updates the activity attribute in category's monthly budget" do
+    month = create(:month, budget_id: budget_id, iso_month: iso_month)
+    monthly_budget = create(:monthly_budget, category: category, month: month)
+    prev_activity = monthly_budget.activity
+
+    described_class.call(
+      amount: amount,
+      budget_id: budget_id,
+      category_id: category.id,
+      iso_month: iso_month,
+    )
+
+    expect(monthly_budget.reload.activity).to eq(prev_activity + amount)
+  end
+
+  it 'updates the month activity' do
+    month = create(:month, budget_id: budget_id, iso_month: iso_month)
+    prev_activity = month.activity
+
+    described_class.call(
+      amount: amount,
+      budget_id: budget_id,
+      category_id: category.id,
+      iso_month: iso_month,
+    )
+
+    expect(month.reload.activity).to eq(prev_activity + amount)
+  end
+
+  it 'returns the updated month' do
+    month = create(:month, budget_id: budget_id, iso_month: iso_month)
+    response = described_class.call(
+      amount: amount,
+      budget_id: budget_id,
+      category_id: category.id,
+      iso_month: iso_month,
+    )
+
+    expect(response).to eq(month.reload)
+  end
+
+  describe 'when there is no monthly budget for the category' do
+    it 'creates a new record' do
+      expect do
+        described_class.call(
+          amount: amount,
+          budget_id: budget_id,
+          category_id: category.id,
+          iso_month: iso_month,
+        )
+      end.to change { MonthlyBudget.count }.by(1)
+    end
+  end
+
+  describe 'when there is no month matching iso_month' do
+    it 'creates a new record' do
+      expect do
+        described_class.call(
+          amount: amount,
+          budget_id: budget_id,
+          category_id: category.id,
+          iso_month: IsoMonth.of(2.months.from_now),
+        )
+      end.to change { Month.count }.by(1)
+    end
+  end
+
+  describe 'when there is no monthly budget for the category' do
+    it 'creates a new record' do
+      expect do
+        described_class.call(
+          amount: amount,
+          budget_id: budget_id,
+          category_id: category.id,
+          iso_month: iso_month,
+        )
+      end.to change { MonthlyBudget.count }.by(1)
+    end
+  end
+end

--- a/spec/services/months/add_income_spec.rb
+++ b/spec/services/months/add_income_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 describe Months::AddIncome do
   let(:budget_id) { create(:budget).id }
-  let(:iso_month) { Time.current.strftime('%Y-%m') }
+  let(:iso_month) { IsoMonth.of(Time.current) }
   let(:amount) { rand(10_000) }
 
   it 'increases income and to_be_budgeted with amount' do
     month = create(
-      :month, budget_id: budget_id, iso_month: Time.current.strftime('%Y-%m')
+      :month, budget_id: budget_id, iso_month: IsoMonth.of(Time.current)
     )
     prev_income = month.income
     prev_to_be_budgeted = month.to_be_budgeted
@@ -24,6 +24,20 @@ describe Months::AddIncome do
       income: prev_income + amount,
       to_be_budgeted: prev_to_be_budgeted + amount,
     )
+  end
+
+  it 'returns the updated record' do
+    month = create(
+      :month, budget_id: budget_id, iso_month: IsoMonth.of(Time.current)
+    )
+
+    response = described_class.call(
+      amount: amount,
+      budget_id: budget_id,
+      iso_month: iso_month,
+    )
+
+    expect(response).to eq(month.reload)
   end
 
   context 'when month does not exist' do

--- a/spec/use_cases/accounts/create_with_starting_balance_spec.rb
+++ b/spec/use_cases/accounts/create_with_starting_balance_spec.rb
@@ -65,7 +65,7 @@ describe Accounts::CreateWithStartingBalance do
     end
 
     it 'does not update month income or to_be_budgeted' do
-      month = create(:month, iso_month: Date.current.strftime('%Y-%m'))
+      month = create(:month, iso_month: IsoMonth.of(Date.current))
       prev_income = month.income
       prev_to_be_budgeted = month.to_be_budgeted
       type = %w[credit].sample

--- a/spec/use_cases/months/fetch_or_create_spec.rb
+++ b/spec/use_cases/months/fetch_or_create_spec.rb
@@ -6,7 +6,7 @@ describe Months::FetchOrCreate do
   let(:params) do
     {
       budget_id: create(:budget).id,
-      iso_month: Faker::Date.in_date_period.strftime('%Y-%m'),
+      iso_month: IsoMonth.of(Faker::Date.in_date_period),
     }
   end
 

--- a/spec/use_cases/transactions/register_spec.rb
+++ b/spec/use_cases/transactions/register_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Transactions::Register do
+  let(:budget) { create(:budget) }
+  let(:payee) { create(:payee, budget: budget) }
+  let(:category) { create(:category, :with_budget, budget: budget) }
+  let(:origin_account) { create(:checking_account) }
+  let(:params) do
+    {
+      amount: Faker::Number.between(from: 1, to: 1000),
+      budget_id: budget.id,
+      cleared_at: Time.current.iso8601,
+      memo: Faker::Lorem.sentence,
+      category_id: category.id,
+      origin_id: origin_account.id,
+      outflow: true,
+      payee_name: payee.name,
+      reference_at: Time.current.iso8601,
+    }
+  end
+
+  before { freeze_time }
+  after { travel_back }
+
+  it 'creates a new transaction', :aggregate_failures do
+    expect do
+      described_class.call(params)
+    end.to change { Transaction.count }.by(1)
+
+    expect(Transaction.last).to have_attributes(
+      cleared_at: DateTime.parse(params[:cleared_at]),
+      memo: params[:memo],
+      origin_id: params[:origin_id],
+      outflow: params[:outflow],
+      payee: payee,
+      reference_at: DateTime.parse(params[:reference_at]),
+    )
+  end
+
+  it 'associate transaction to the categories monthly budget' do
+    transaction = described_class.call(params)
+
+    expect(transaction.monthly_budget.category).to eq(category)
+  end
+
+  it 'updates account balance' do
+    allow(Accounts::UpdateBalance).to receive(:call)
+
+    described_class.call(params)
+
+    expect(Accounts::UpdateBalance).to have_received(:call).with(
+      account: origin_account,
+      transaction: Transaction.last,
+    )
+  end
+
+  context 'when category is present' do
+    it 'updates month activity' do
+      month = create(
+        :month, budget: budget, iso_month: IsoMonth.of(Time.current)
+      )
+
+      expect do
+        described_class.call(params.merge(outflow: true))
+      end.to change { month.reload.activity }.by(params[:amount])
+    end
+  end
+
+  context 'when category is missing' do
+    it 'updates month income' do
+      month = create(
+        :month, budget: budget, iso_month: IsoMonth.of(Time.current)
+      )
+
+      expect do
+        described_class.call(params.merge(category_id: nil))
+      end.to change { month.reload.income }.by(params[:amount])
+    end
+  end
+
+  context 'when transaction is outflow' do
+    it 'creates transaction with negative amount' do
+      transaction = described_class.call(params.merge(outflow: true))
+
+      expect(transaction.amount).to eq(-params[:amount])
+    end
+  end
+
+  context 'when transaction is inflow' do
+    it 'creates a transaction with positive amount' do
+      transaction = described_class.call(params.merge(outflow: false))
+
+      expect(transaction.amount).to eq(params[:amount])
+    end
+  end
+
+  context 'when payee does not exist yet' do
+    let(:payee) { build(:payee, name: 'a-payee') }
+
+    it 'creates a new payee' do
+      expect do
+        described_class.call(params.merge(payee_name: 'other-payee'))
+      end.to change { Payee.count }.by(1)
+
+      expect(Transaction.last.payee.name).to eq('other-payee')
+    end
+  end
+end

--- a/spec/values/iso_month_spec.rb
+++ b/spec/values/iso_month_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe IsoMonth do
+  describe '.of' do
+    context 'when arg is a string' do
+      it 'parses date and formats to YYYY-mm', :aggregate_failures do
+        expect(IsoMonth.of('2021-04-29T14:58:30+00:00')).to eq('2021-04')
+        expect(IsoMonth.of('20210101T145830Z')).to eq('2021-01')
+        expect(IsoMonth.of('2021-12-31')).to eq('2021-12')
+      end
+
+      context 'when arg is a date' do
+        it 'formats to YYYY-mm', :aggregate_failures do
+          expect(IsoMonth.of(Date.parse('2021-04-29T14:58:30+00:00'))).to eq('2021-04')
+          expect(IsoMonth.of(Date.parse('20210101T145830Z'))).to eq('2021-01')
+          expect(IsoMonth.of(Date.parse('2021-12-31'))).to eq('2021-12')
+        end
+      end
+    end
+  end
+end

--- a/spec/values/iso_month_spec.rb
+++ b/spec/values/iso_month_spec.rb
@@ -13,7 +13,9 @@ describe IsoMonth do
 
       context 'when arg is a date' do
         it 'formats to YYYY-mm', :aggregate_failures do
-          expect(IsoMonth.of(Date.parse('2021-04-29T14:58:30+00:00'))).to eq('2021-04')
+          expect(IsoMonth.of(Date.parse('2021-04-29T14:58:30+00:00'))).to(
+            eq('2021-04'),
+          )
           expect(IsoMonth.of(Date.parse('20210101T145830Z'))).to eq('2021-01')
           expect(IsoMonth.of(Date.parse('2021-12-31'))).to eq('2021-12')
         end


### PR DESCRIPTION
📓 **CHANGELOG**
- Create a new `IsoMonth` class to abstract this logic
- Add a `Transactions::Register` use case to handle creating new transactions, as long as a `Months::AddActivity`
- Refactor `Months::AddIncome` to return the updated month object after being processed