### PR TITLE
Introduce transfers between accounts

### DIFF
--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -30,19 +30,19 @@ module Api
 
     def serialize(records)
       Api::TransactionSerializer.new(
-        records, include: %i[monthly_budget origin payee]
+        records, include: %i[monthly_budget account payee]
       )
     end
 
     def create_params
       params.permit(
         :amount, :budget_id, :cleared_at, :category_id, :id,
-        :memo, :origin_id, :outflow, :payee_name, :reference_at
+        :memo, :account_id, :outflow, :payee_name, :reference_at
       )
     end
 
     def index_params
-      params.permit(:origin_id)
+      params.permit(:account_id)
     end
   end
 end

--- a/app/controllers/api/transfers_controller.rb
+++ b/app/controllers/api/transfers_controller.rb
@@ -12,6 +12,13 @@ module Api
       render json: serialize(transactions)
     end
 
+    # PUT /api/budgets/:budget_id/transfers
+    def update
+      transactions = Transactions::UpdateTransfer.call(update_params)
+
+      render json: serialize(transactions)
+    end
+
     private
 
     def serialize(records)
@@ -22,8 +29,14 @@ module Api
 
     def create_params
       params.permit(
-        :amount, :budget_id, :category_id, :destination_id, :id,
-        :memo, :origin_id, :outflow, :reference_at, :type
+        :amount, :budget_id, :category_id, :cleared_at, :destination_id,
+        :id, :memo, :origin_id, :outflow, :reference_at, :type
+      )
+    end
+
+    def update_params
+      create_params.merge(
+        params.permit(:destination_transaction_id, :origin_transaction_id)
       )
     end
   end

--- a/app/controllers/api/transfers_controller.rb
+++ b/app/controllers/api/transfers_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  class TransfersController < ApplicationController
+    before_action :authenticate_user!
+    before_action :authorize_budget!
+
+    # POST /api/budgets/:budget_id/transfers
+    def create
+      transactions = Transactions::CreateTransfer.call(create_params)
+
+      render json: serialize(transactions)
+    end
+
+    private
+
+    def serialize(records)
+      Api::TransactionSerializer.new(
+        records, include: %i[monthly_budget account payee]
+      )
+    end
+
+    def create_params
+      params.permit(
+        :amount, :budget_id, :category_id, :destination_id, :id,
+        :memo, :origin_id, :outflow, :reference_at, :type
+      )
+    end
+  end
+end

--- a/app/controllers/api/transfers_controller.rb
+++ b/app/controllers/api/transfers_controller.rb
@@ -36,7 +36,7 @@ module Api
 
     def update_params
       create_params.merge(
-        params.permit(:destination_transaction_id, :origin_transaction_id)
+        params.permit(:destination_transaction_id, :origin_transaction_id),
       )
     end
   end

--- a/app/models/account/base.rb
+++ b/app/models/account/base.rb
@@ -12,6 +12,10 @@ module Account
       nature.eql?(:budget)
     end
 
+    def tracking?
+      !budget?
+    end
+
     def balance
       cleared_balance + uncleared_balance
     end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,9 +2,13 @@
 
 class Transaction < ApplicationRecord
   belongs_to :payee
-  belongs_to :origin, class_name: 'Account::Base'
+  belongs_to :account, class_name: 'Account::Base'
   belongs_to :monthly_budget, optional: true
   belongs_to :month
+  belongs_to :linked_transaction,
+             class_name: 'Transaction',
+            foreign_key: 'linked_transaction_id',
+            optional: true
 
   validates :amount, :reference_at, presence: true
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -7,8 +7,8 @@ class Transaction < ApplicationRecord
   belongs_to :month
   belongs_to :linked_transaction,
              class_name: 'Transaction',
-            foreign_key: 'linked_transaction_id',
-            optional: true
+             foreign_key: 'linked_transaction_id',
+             optional: true
 
   validates :amount, :reference_at, presence: true
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Transaction < ApplicationRecord
-  belongs_to :payee
+  belongs_to :payee, optional: true
   belongs_to :account, class_name: 'Account::Base'
   belongs_to :monthly_budget, optional: true
   belongs_to :month

--- a/app/queries/transactions_query.rb
+++ b/app/queries/transactions_query.rb
@@ -2,7 +2,7 @@
 
 class TransactionsQuery < ApplicationQuery
   def execute
-    filter_origin_id
+    filter_account_id
     sort
   end
 
@@ -12,10 +12,10 @@ class TransactionsQuery < ApplicationQuery
 
   private
 
-  def filter_origin_id
-    return unless params.key?(:origin_id)
+  def filter_account_id
+    return unless params.key?(:account_id)
 
-    @relation = relation.where(origin_id: params[:origin_id])
+    @relation = relation.where(account_id: params[:account_id])
   end
 
   def sort

--- a/app/serializers/api/account_serializer.rb
+++ b/app/serializers/api/account_serializer.rb
@@ -9,6 +9,9 @@ module Api
                :nature,
                :uncleared_balance
 
+    attribute :is_budget, &:budget?
+    attribute :is_tracking, &:tracking?
+
     attribute :type do |obj|
       obj.type.split('::').last.downcase
     end

--- a/app/serializers/api/month_serializer.rb
+++ b/app/serializers/api/month_serializer.rb
@@ -4,6 +4,7 @@ module Api
   class MonthSerializer < ApplicationSerializer
     attributes :activity,
                :budgeted,
+               :budget_id,
                :income,
                :iso_month,
                :to_be_budgeted

--- a/app/serializers/api/transaction_serializer.rb
+++ b/app/serializers/api/transaction_serializer.rb
@@ -4,10 +4,9 @@ module Api
   class TransactionSerializer < ApplicationSerializer
     attributes :amount,
                :cleared_at,
-               :destination_id,
                :memo,
                :monthly_budget_id,
-               :origin_id,
+               :account_id,
                :outflow,
                :payee_id,
                :reference_at,
@@ -23,6 +22,6 @@ module Api
 
     belongs_to :monthly_budget
     belongs_to :payee
-    belongs_to :origin, serializer: AccountSerializer
+    belongs_to :account, serializer: AccountSerializer
   end
 end

--- a/app/serializers/api/transaction_serializer.rb
+++ b/app/serializers/api/transaction_serializer.rb
@@ -2,11 +2,12 @@
 
 module Api
   class TransactionSerializer < ApplicationSerializer
-    attributes :amount,
+    attributes :account_id,
+               :amount,
                :cleared_at,
+               :linked_transaction_id,
                :memo,
                :monthly_budget_id,
-               :account_id,
                :outflow,
                :payee_id,
                :reference_at,
@@ -17,7 +18,11 @@ module Api
     end
 
     attribute :payee_name do |object|
-      object.payee.name
+      object.payee&.name
+    end
+
+    attribute :linked_transaction_account_id do |object|
+      object.linked_transaction&.account_id
     end
 
     belongs_to :monthly_budget

--- a/app/services/transactions/update.rb
+++ b/app/services/transactions/update.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# FIXME: move me into update
 module Transactions
   class Update < ApplicationService
     def initialize(transaction:, updated_params:)

--- a/app/services/transactions/update.rb
+++ b/app/services/transactions/update.rb
@@ -21,7 +21,7 @@ module Transactions
       {
         amount: signed_amount,
         cleared_at: params[:cleared_at],
-        origin_id: params[:origin_id],
+        account_id: params[:account_id],
         outflow: params[:outflow],
         payee: payee,
         memo: params[:memo],

--- a/app/use_cases/accounts/create_with_starting_balance.rb
+++ b/app/use_cases/accounts/create_with_starting_balance.rb
@@ -45,7 +45,7 @@ module Accounts
       @transaction = Transaction.create!(
         amount: initial_balance,
         cleared_at: DateTime.current,
-        origin: account,
+        account: account,
         outflow: account.debt?,
         month: month,
         payee: starting_balance_payee,

--- a/app/use_cases/transactions/create_transfer.rb
+++ b/app/use_cases/transactions/create_transfer.rb
@@ -64,10 +64,10 @@ module Transactions
 
     def link_transactions
       origin_transaction.update!(
-        linked_transaction_id: destination_transaction.id
+        linked_transaction_id: destination_transaction.id,
       )
       destination_transaction.update!(
-        linked_transaction_id: origin_transaction.id
+        linked_transaction_id: origin_transaction.id,
       )
     end
 

--- a/app/use_cases/transactions/create_transfer.rb
+++ b/app/use_cases/transactions/create_transfer.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Transactions
+  class CreateTransfer < ApplicationUseCase
+    def initialize(params)
+      @params = params
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        create_origin_transaction
+        create_destination_transaction
+        link_transactions
+        update_accounts_balance
+        update_month
+        reload_objects
+
+        [origin_transaction, destination_transaction]
+      end
+    end
+
+    private
+
+    attr_accessor :origin_transaction, :destination_transaction
+
+    def create_origin_transaction
+      @origin_transaction = Transaction.create!(
+        amount: signed_amount,
+        cleared_at: params[:cleared_at],
+        account_id: params[:origin_id],
+        outflow: params[:outflow],
+        memo: params[:memo],
+        month: month,
+        monthly_budget: monthly_budget,
+        reference_at: params[:reference_at],
+      )
+    end
+
+    def create_destination_transaction
+      @destination_transaction = Transaction.create!(
+        amount: -signed_amount,
+        cleared_at: params[:cleared_at],
+        account_id: params[:destination_id],
+        outflow: !params[:outflow],
+        memo: params[:memo],
+        month: month,
+        monthly_budget: monthly_budget,
+        reference_at: params[:reference_at],
+      )
+    end
+
+    def update_accounts_balance
+      ::Accounts::UpdateBalance.call(
+        account: origin_transaction.account,
+        amount: origin_transaction.amount,
+        cleared: origin_transaction.cleared?,
+      )
+      ::Accounts::UpdateBalance.call(
+        account: destination_transaction.account,
+        amount: destination_transaction.amount,
+        cleared: destination_transaction.cleared?,
+      )
+    end
+
+    def link_transactions
+      origin_transaction.update!(
+        linked_transaction_id: destination_transaction.id
+      )
+      destination_transaction.update!(
+        linked_transaction_id: origin_transaction.id
+      )
+    end
+
+    def update_month
+      return if rebalance?
+
+      amount_type = spending? ? :activity : :income
+
+      MonthlyBudgets::UpdateAmount.call(
+        amount: signed_amount,
+        amount_type: amount_type,
+        month: month,
+        monthly_budget: monthly_budget,
+      )
+    end
+
+    def reload_objects
+      origin_transaction.reload
+      destination_transaction.reload
+    end
+
+    def signed_amount
+      -params[:amount]
+    end
+
+    def month
+      @month ||= Months::FetchOrCreate.call(
+        budget_id: params[:budget_id],
+        iso_month: IsoMonth.of(params[:reference_at]),
+      )
+    end
+
+    def monthly_budget
+      return unless spending?
+
+      @monthly_budget ||= ::MonthlyBudgets::FetchOrCreate.call(
+        params: params.merge(month: month),
+      )
+    end
+
+    def spending?
+      params[:type].to_sym == :spending
+    end
+
+    def rebalance?
+      params[:type].to_sym == :rebalance
+    end
+  end
+end

--- a/app/use_cases/transactions/register.rb
+++ b/app/use_cases/transactions/register.rb
@@ -26,7 +26,7 @@ module Transactions
       @transaction = Transaction.create!(
         amount: signed_amount,
         cleared_at: params[:cleared_at],
-        origin_id: params[:origin_id],
+        account_id: params[:account_id],
         outflow: params[:outflow],
         payee: payee,
         memo: params[:memo],
@@ -50,7 +50,7 @@ module Transactions
 
     def update_account_balance
       ::Accounts::UpdateBalance.call(
-        account: origin_account,
+        account: account,
         amount: transaction.amount,
         cleared: transaction.cleared?,
       )
@@ -88,8 +88,8 @@ module Transactions
       )
     end
 
-    def origin_account
-      @origin_account ||= ::Account::Base.find(params[:origin_id])
+    def account
+      @account ||= ::Account::Base.find(params[:account_id])
     end
   end
 end

--- a/app/use_cases/transactions/update_and_rebudget.rb
+++ b/app/use_cases/transactions/update_and_rebudget.rb
@@ -40,7 +40,7 @@ module Transactions
         monthly_budget: transaction.monthly_budget,
       )
       Accounts::UpdateBalance.call(
-        account: transaction.origin,
+        account: transaction.account,
         amount: -transaction.amount,
         cleared: transaction.cleared?,
       )
@@ -56,7 +56,7 @@ module Transactions
         monthly_budget: transaction.monthly_budget,
       )
       Accounts::UpdateBalance.call(
-        account: transaction.origin,
+        account: transaction.account,
         amount: transaction.amount,
         cleared: transaction.cleared?,
       )

--- a/app/use_cases/transactions/update_transfer.rb
+++ b/app/use_cases/transactions/update_transfer.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Transactions
+  class UpdateTransfer < ApplicationUseCase
+    def initialize(params)
+      @params = params
+      @origin_transaction = Transaction.find(params[:origin_transaction_id])
+      @destination_transaction = Transaction.find(params[:destination_transaction_id])
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        undo_budgeting
+        undo_accounts_balance
+        update_origin_transaction
+        update_destination_transaction
+        add_budgeting
+        add_accounts_balance
+        reload_objects
+
+        [origin_transaction, destination_transaction]
+      end
+    end
+
+    private
+
+    attr_accessor :origin_transaction, :destination_transaction
+
+    def undo_budgeting
+      return if natures_match?
+
+      amount_type = origin_transaction.monthly_budget.present? ? :activity : :income
+
+      MonthlyBudgets::UpdateAmount.call(
+        amount: -origin_transaction.amount,
+        amount_type: amount_type,
+        month: origin_transaction.month,
+        monthly_budget: origin_transaction.monthly_budget,
+      )
+    end
+
+    def undo_accounts_balance
+      Accounts::UpdateBalance.call(
+        account: origin_transaction.account,
+        amount: -origin_transaction.amount,
+        cleared: origin_transaction.cleared?,
+      )
+      Accounts::UpdateBalance.call(
+        account: destination_transaction.account,
+        amount: -destination_transaction.amount,
+        cleared: destination_transaction.cleared?,
+      )
+    end
+
+    def add_budgeting
+      return if natures_match?
+
+      amount_type = origin_transaction.monthly_budget.present? ? :activity : :income
+
+      MonthlyBudgets::UpdateAmount.call(
+        amount: params[:amount],
+        amount_type: amount_type,
+        month: origin_transaction.month,
+        monthly_budget: origin_transaction.monthly_budget,
+      )
+    end
+
+    def add_accounts_balance
+      Accounts::UpdateBalance.call(
+        account: origin_transaction.account,
+        amount: origin_transaction.amount,
+        cleared: origin_transaction.cleared?,
+      )
+      Accounts::UpdateBalance.call(
+        account: destination_transaction.account,
+        amount: destination_transaction.amount,
+        cleared: destination_transaction.cleared?,
+      )
+    end
+
+    def reload_objects
+      origin_transaction.reload
+      destination_transaction.reload
+    end
+
+    def natures_match?
+      origin_transaction.account.nature === destination_transaction.account.nature
+    end
+
+    def spending?
+      params[:type].to_sym == :spending
+    end
+
+    def update_origin_transaction
+      origin_transaction.update!(
+        amount: signed_amount,
+        cleared_at: params[:cleared_at],
+        account_id: params[:origin_id],
+        outflow: true,
+        memo: params[:memo],
+        month: new_month,
+        monthly_budget: new_monthly_budget,
+        reference_at: params[:reference_at],
+      )
+    end
+
+    def update_destination_transaction
+      destination_transaction.update!(
+        amount: -signed_amount,
+        cleared_at: params[:cleared_at],
+        account_id: params[:destination_id],
+        outflow: false,
+        memo: params[:memo],
+        month: new_month,
+        monthly_budget: new_monthly_budget,
+        reference_at: params[:reference_at],
+      )
+    end
+
+    def signed_amount
+      -params[:amount]
+    end
+
+    def new_month
+      @new_month ||= Months::FetchOrCreate.call(
+        budget_id: params[:budget_id],
+        iso_month: IsoMonth.of(params[:reference_at]),
+      )
+    end
+
+    def new_monthly_budget
+      return unless spending?
+
+      @new_monthly_budget ||= ::MonthlyBudgets::FetchOrCreate.call(
+        params: params.merge(month: new_month),
+      )
+    end
+  end
+end

--- a/app/use_cases/transactions/update_transfer.rb
+++ b/app/use_cases/transactions/update_transfer.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module Transactions
   class UpdateTransfer < ApplicationUseCase
     def initialize(params)
       @params = params
-      @origin_transaction = Transaction.find(params[:origin_transaction_id])
-      @destination_transaction = Transaction.find(params[:destination_transaction_id])
+      @origin_transaction = Transaction.find(
+        params[:origin_transaction_id],
+      )
+      @destination_transaction = Transaction.find(
+        params[:destination_transaction_id],
+      )
     end
 
     def call
@@ -28,8 +33,6 @@ module Transactions
 
     def undo_budgeting
       return if natures_match?
-
-      amount_type = origin_transaction.monthly_budget.present? ? :activity : :income
 
       MonthlyBudgets::UpdateAmount.call(
         amount: -origin_transaction.amount,
@@ -54,8 +57,6 @@ module Transactions
 
     def add_budgeting
       return if natures_match?
-
-      amount_type = origin_transaction.monthly_budget.present? ? :activity : :income
 
       MonthlyBudgets::UpdateAmount.call(
         amount: params[:amount],
@@ -84,7 +85,14 @@ module Transactions
     end
 
     def natures_match?
-      origin_transaction.account.nature === destination_transaction.account.nature
+      origin_transaction.account.nature ==
+        destination_transaction.account.nature
+    end
+
+    def amount_type
+      return :activity if origin_transaction.monthly_budget.present?
+
+      :income
     end
 
     def spending?
@@ -137,3 +145,4 @@ module Transactions
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,11 @@ Rails.application.routes.draw do
       resources :monthly_budgets, only: %i[create index update]
       resources :payees, only: %i[index]
       resources :transactions, only: %i[create index update]
-      resources :transfers, only: %i[create update]
+      resources :transfers, only: %i[create] do
+        collection do
+          put :update
+        end
+      end
     end
 
     resources :users, only: %i[create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       resources :monthly_budgets, only: %i[create index update]
       resources :payees, only: %i[index]
       resources :transactions, only: %i[create index update]
+      resources :transfers, only: %i[create update]
     end
 
     resources :users, only: %i[create]

--- a/db/migrate/20210913211348_add_linked_transaction_id.rb
+++ b/db/migrate/20210913211348_add_linked_transaction_id.rb
@@ -1,0 +1,7 @@
+class AddLinkedTransactionId < ActiveRecord::Migration[6.1]
+  def change
+    add_column :transactions, :linked_transaction_id, :uuid, null: true
+    remove_column :transactions, :destination_id, :uuid
+    rename_column :transactions, :origin_id, :account_id
+  end
+end

--- a/db/migrate/20210914044603_make_payee_id_nullable.rb
+++ b/db/migrate/20210914044603_make_payee_id_nullable.rb
@@ -1,0 +1,5 @@
+class MakePayeeIdNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :transactions, :payee_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_07_220655) do
+ActiveRecord::Schema.define(version: 2021_09_13_211348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -85,11 +85,11 @@ ActiveRecord::Schema.define(version: 2021_08_07_220655) do
     t.integer "amount", null: false
     t.uuid "payee_id", null: false
     t.uuid "monthly_budget_id"
-    t.uuid "origin_id", null: false
-    t.uuid "destination_id"
+    t.uuid "account_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "month_id"
+    t.uuid "linked_transaction_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_211348) do
+ActiveRecord::Schema.define(version: 2021_09_14_044603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_211348) do
     t.datetime "reference_at", null: false
     t.datetime "cleared_at"
     t.integer "amount", null: false
-    t.uuid "payee_id", null: false
+    t.uuid "payee_id"
     t.uuid "monthly_budget_id"
     t.uuid "account_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :transaction do
     amount { rand(-100_000..100_000) }
     cleared_at { DateTime.current }
-    origin { create(:random_account) }
+    account { create(:random_account) }
     reference_at { Faker::Date.between(from: 1.month.ago, to: Date.current) }
 
     month

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
     trait :uncleared do
       cleared_at { nil }
     end
+
+    trait :with_linked_transaction do
+      linked_transaction { create(:transaction) }
+    end
   end
 end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 describe Transaction do
   describe 'relationships' do
     it { is_expected.to belong_to(:payee) }
-    it { is_expected.to belong_to(:origin).class_name('Account::Base') }
+    it { is_expected.to belong_to(:account).class_name('Account::Base') }
     it { is_expected.to belong_to(:monthly_budget).optional(true) }
     it { is_expected.to belong_to(:month) }
+    it { is_expected.to belong_to(:linked_transaction).optional(true) }
   end
 
   describe 'validations' do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Transaction do
   describe 'relationships' do
-    it { is_expected.to belong_to(:payee) }
+    it { is_expected.to belong_to(:payee).optional(true) }
     it { is_expected.to belong_to(:account).class_name('Account::Base') }
     it { is_expected.to belong_to(:monthly_budget).optional(true) }
     it { is_expected.to belong_to(:month) }

--- a/spec/queries/transactions_query_spec.rb
+++ b/spec/queries/transactions_query_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 describe TransactionsQuery do
-  it 'filters by origin id' do
+  it 'filters by account id' do
     transaction = create(:transaction)
     create(:transaction)
 
-    response = described_class.execute(origin_id: transaction.origin_id)
+    response = described_class.execute(account_id: transaction.account_id)
 
     expect(response).to contain_exactly(transaction)
   end

--- a/spec/serializers/api/account_serializer_spec.rb
+++ b/spec/serializers/api/account_serializer_spec.rb
@@ -17,6 +17,8 @@ describe Api::AccountSerializer do
           balance: account.balance,
           cleared_balance: account.cleared_balance,
           closed_at: account.closed_at,
+          is_budget: account.budget?,
+          is_tracking: account.tracking?,
           name: account.name,
           nature: account.nature,
           uncleared_balance: account.uncleared_balance,

--- a/spec/serializers/api/month_serializer_spec.rb
+++ b/spec/serializers/api/month_serializer_spec.rb
@@ -15,6 +15,7 @@ describe Api::MonthSerializer do
         attributes: {
           activity: month.activity,
           budgeted: month.budgeted,
+          budget_id: month.budget_id,
           income: month.income,
           iso_month: month.iso_month,
           to_be_budgeted: month.to_be_budgeted,

--- a/spec/serializers/api/transaction_serializer_spec.rb
+++ b/spec/serializers/api/transaction_serializer_spec.rb
@@ -18,6 +18,8 @@ describe Api::TransactionSerializer do
           cleared_at: transaction.cleared_at,
           memo: transaction.memo,
           monthly_budget_id: transaction.monthly_budget_id,
+          linked_transaction_id: nil,
+          linked_transaction_account_id: nil,
           account_id: transaction.account_id,
           outflow: transaction.outflow,
           payee_id: transaction.payee_id,
@@ -61,6 +63,25 @@ describe Api::TransactionSerializer do
           type: :transaction,
           attributes: hash_including(
             category_id: nil,
+          ),
+        ),
+      )
+    end
+  end
+
+  context 'when transaction has a linked transaction' do
+    it "renders linked_transaction's account_id" do
+      transaction = create(:transaction, :with_linked_transaction)
+
+      result = described_class.new(transaction).serializable_hash
+
+      expect(result).to include(
+        data: hash_including(
+          id: transaction.id,
+          type: :transaction,
+          attributes: hash_including(
+            linked_transaction_id: transaction.linked_transaction_id,
+            linked_transaction_account_id: transaction.linked_transaction.account_id,
           ),
         ),
       )

--- a/spec/serializers/api/transaction_serializer_spec.rb
+++ b/spec/serializers/api/transaction_serializer_spec.rb
@@ -16,10 +16,9 @@ describe Api::TransactionSerializer do
           amount: transaction.amount,
           category_id: transaction.monthly_budget.category_id,
           cleared_at: transaction.cleared_at,
-          destination_id: transaction.destination_id,
           memo: transaction.memo,
           monthly_budget_id: transaction.monthly_budget_id,
-          origin_id: transaction.origin_id,
+          account_id: transaction.account_id,
           outflow: transaction.outflow,
           payee_id: transaction.payee_id,
           payee_name: transaction.payee.name,
@@ -33,9 +32,9 @@ describe Api::TransactionSerializer do
               type: :monthly_budget,
             },
           },
-          origin: {
+          account: {
             data: {
-              id: transaction.origin_id,
+              id: transaction.account_id,
               type: :account,
             },
           },

--- a/spec/serializers/api/transaction_serializer_spec.rb
+++ b/spec/serializers/api/transaction_serializer_spec.rb
@@ -81,7 +81,8 @@ describe Api::TransactionSerializer do
           type: :transaction,
           attributes: hash_including(
             linked_transaction_id: transaction.linked_transaction_id,
-            linked_transaction_account_id: transaction.linked_transaction.account_id,
+            linked_transaction_account_id:
+              transaction.linked_transaction.account_id,
           ),
         ),
       )

--- a/spec/services/transactions/update_spec.rb
+++ b/spec/services/transactions/update_spec.rb
@@ -7,7 +7,7 @@ describe Transactions::Update do
   let(:budget) { create(:budget) }
   let(:payee) { create(:payee, budget: budget) }
   let(:category) { create(:category, :with_budget, budget: budget) }
-  let(:origin_account) { create(:checking_account) }
+  let(:account) { create(:checking_account) }
   let(:params) do
     {
       amount: Faker::Number.between(from: 1, to: 1000),
@@ -15,7 +15,7 @@ describe Transactions::Update do
       cleared_at: Time.current.iso8601,
       memo: Faker::Lorem.sentence,
       category_id: category.id,
-      origin_id: origin_account.id,
+      account_id: account.id,
       outflow: true,
       payee_name: payee.name,
       reference_at: Time.current.iso8601,
@@ -33,7 +33,7 @@ describe Transactions::Update do
       amount: -params[:amount],
       cleared_at: DateTime.parse(params[:cleared_at]),
       memo: params[:memo],
-      origin_id: params[:origin_id],
+      account_id: params[:account_id],
       outflow: params[:outflow],
       reference_at: DateTime.parse(params[:reference_at]),
     )

--- a/spec/use_cases/transactions/create_transfer_spec.rb
+++ b/spec/use_cases/transactions/create_transfer_spec.rb
@@ -32,7 +32,7 @@ describe Transactions::CreateTransfer do
     expect(transactions.first).to have_attributes(
       outflow: true,
       account_id: origin_account.id,
-      amount: -params[:amount]
+      amount: -params[:amount],
     )
   end
 
@@ -42,7 +42,7 @@ describe Transactions::CreateTransfer do
     expect(transactions.last).to have_attributes(
       outflow: false,
       account_id: destination_account.id,
-      amount: params[:amount]
+      amount: params[:amount],
     )
   end
 
@@ -62,7 +62,9 @@ describe Transactions::CreateTransfer do
   it 'updates destination account balance' do
     expect do
       described_class.call(params)
-    end.to change { destination_account.reload.cleared_balance }.by(params[:amount])
+    end.to change {
+             destination_account.reload.cleared_balance
+           }.by(params[:amount])
   end
 
   it 'does not change monthly budgets for :rebalance transfers' do
@@ -86,8 +88,8 @@ describe Transactions::CreateTransfer do
       expect(MonthlyBudgets::UpdateAmount).to have_received(:call).with(
         hash_including(
           amount: -params[:amount],
-          amount_type: :income
-        )
+          amount_type: :income,
+        ),
       )
     end
   end
@@ -105,8 +107,8 @@ describe Transactions::CreateTransfer do
       expect(MonthlyBudgets::UpdateAmount).to have_received(:call).with(
         hash_including(
           amount: -params[:amount],
-          amount_type: :activity
-        )
+          amount_type: :activity,
+        ),
       )
     end
   end

--- a/spec/use_cases/transactions/create_transfer_spec.rb
+++ b/spec/use_cases/transactions/create_transfer_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Transactions::CreateTransfer do
+  let(:budget) { create(:budget) }
+  let(:category_id) { create(:category, :with_budget, budget: budget).id }
+  let(:origin_account) { create(:checking_account) }
+  let(:destination_account) { create(:checking_account) }
+  let(:transfer_type) { :rebalance }
+  let(:params) do
+    {
+      amount: Faker::Number.between(from: 1, to: 1000),
+      budget_id: budget.id,
+      category_id: category_id,
+      cleared_at: Time.current.iso8601,
+      destination_id: destination_account.id,
+      memo: Faker::Lorem.sentence,
+      origin_id: origin_account.id,
+      outflow: true,
+      type: transfer_type,
+      reference_at: Time.current.iso8601,
+    }
+  end
+
+  before { freeze_time }
+  after { travel_back }
+
+  it 'creates an outbound transaction on origin account' do
+    transactions = described_class.call(params)
+
+    expect(transactions.first).to have_attributes(
+      outflow: true,
+      account_id: origin_account.id,
+      amount: -params[:amount]
+    )
+  end
+
+  it 'creates an inbound transaction on destination account' do
+    transactions = described_class.call(params)
+
+    expect(transactions.last).to have_attributes(
+      outflow: false,
+      account_id: destination_account.id,
+      amount: params[:amount]
+    )
+  end
+
+  it 'links both transactions together', :aggregate_failures do
+    transactions = described_class.call(params)
+
+    expect(transactions.first.linked_transaction).to eq(transactions.last)
+    expect(transactions.last.linked_transaction).to eq(transactions.first)
+  end
+
+  it 'updates origin account balance' do
+    expect do
+      described_class.call(params)
+    end.to change { origin_account.reload.cleared_balance }.by(-params[:amount])
+  end
+
+  it 'updates destination account balance' do
+    expect do
+      described_class.call(params)
+    end.to change { destination_account.reload.cleared_balance }.by(params[:amount])
+  end
+
+  it 'does not change monthly budgets for :rebalance transfers' do
+    allow(MonthlyBudgets::UpdateAmount).to receive(:call)
+
+    described_class.call(params)
+
+    expect(MonthlyBudgets::UpdateAmount).not_to have_received(:call)
+  end
+
+  context 'when transfer is a :income' do
+    let(:origin_account) { create(:asset_account) }
+    let(:destination_account) { create(:checking_account) }
+    let(:transfer_type) { :income }
+
+    it "updates month's income" do
+      allow(MonthlyBudgets::UpdateAmount).to receive(:call)
+
+      described_class.call(params)
+
+      expect(MonthlyBudgets::UpdateAmount).to have_received(:call).with(
+        hash_including(
+          amount: -params[:amount],
+          amount_type: :income
+        )
+      )
+    end
+  end
+
+  context 'when transfer is a :spending' do
+    let(:origin_account) { create(:checking_account) }
+    let(:destination_account) { create(:asset_account) }
+    let(:transfer_type) { :spending }
+
+    it "updates month's income" do
+      allow(MonthlyBudgets::UpdateAmount).to receive(:call)
+
+      described_class.call(params)
+
+      expect(MonthlyBudgets::UpdateAmount).to have_received(:call).with(
+        hash_including(
+          amount: -params[:amount],
+          amount_type: :activity
+        )
+      )
+    end
+  end
+end

--- a/spec/use_cases/transactions/register_spec.rb
+++ b/spec/use_cases/transactions/register_spec.rb
@@ -6,7 +6,7 @@ describe Transactions::Register do
   let(:budget) { create(:budget) }
   let(:payee) { create(:payee, budget: budget) }
   let(:category) { create(:category, :with_budget, budget: budget) }
-  let(:origin_account) { create(:checking_account) }
+  let(:account) { create(:checking_account) }
   let(:params) do
     {
       amount: Faker::Number.between(from: 1, to: 1000),
@@ -14,7 +14,7 @@ describe Transactions::Register do
       cleared_at: Time.current.iso8601,
       memo: Faker::Lorem.sentence,
       category_id: category.id,
-      origin_id: origin_account.id,
+      account_id: account.id,
       outflow: true,
       payee_name: payee.name,
       reference_at: Time.current.iso8601,
@@ -32,7 +32,7 @@ describe Transactions::Register do
     expect(Transaction.last).to have_attributes(
       cleared_at: DateTime.parse(params[:cleared_at]),
       memo: params[:memo],
-      origin_id: params[:origin_id],
+      account_id: params[:account_id],
       outflow: params[:outflow],
       payee: payee,
       reference_at: DateTime.parse(params[:reference_at]),
@@ -53,7 +53,7 @@ describe Transactions::Register do
     transaction = Transaction.last
 
     expect(Accounts::UpdateBalance).to have_received(:call).with(
-      account: origin_account,
+      account: account,
       amount: transaction.amount,
       cleared: transaction.cleared?,
     )

--- a/spec/use_cases/transactions/update_and_rebudget_spec.rb
+++ b/spec/use_cases/transactions/update_and_rebudget_spec.rb
@@ -29,7 +29,7 @@ describe Transactions::UpdateAndRebudget do
       cleared_at: nil,
       id: transaction.id,
       memo: Faker::Lorem.sentence,
-      origin_id: transaction.origin_id,
+      account_id: transaction.account_id,
       outflow: true,
       payee_name: new_payee.name,
       reference_at: new_reference,
@@ -47,7 +47,7 @@ describe Transactions::UpdateAndRebudget do
     expect(Transaction.last).to have_attributes(
       cleared_at: nil,
       memo: params[:memo],
-      origin_id: params[:origin_id],
+      account_id: params[:account_id],
       outflow: params[:outflow],
       payee: new_payee,
       monthly_budget: new_monthly_budget,


### PR DESCRIPTION
🌟 **NEW**
- Add new endpoints to create and edit transfers
- Add a new `transactions#linkedTransactionId` field for when transactions are part of a 2-step patch

🧹 TECHIES
- Transfers have now a **single** relationship with account, denoted by `accountId`, instead of two