### PR TITLE
Use correct signed amounts when creating/editing transfers

### DIFF
--- a/app/models/month.rb
+++ b/app/models/month.rb
@@ -10,4 +10,8 @@ class Month < ApplicationRecord
             :activity,
             :to_be_budgeted,
             presence: true
+
+  validates :income, numericality: { greater_than_or_equal_to: 0 }
+  validates :budgeted, numericality: { greater_than_or_equal_to: 0 }
+  validates :activity, numericality: { less_than_or_equal_to: 0 }
 end

--- a/app/models/monthly_budget.rb
+++ b/app/models/monthly_budget.rb
@@ -5,6 +5,9 @@ class MonthlyBudget < ApplicationRecord
   belongs_to :month
   has_many :transactions
 
+  validates :budgeted, numericality: { greater_than_or_equal_to: 0 }
+  validates :activity, numericality: { less_than_or_equal_to: 0 }
+
   def available
     budgeted + activity
   end

--- a/app/use_cases/transactions/create_transfer.rb
+++ b/app/use_cases/transactions/create_transfer.rb
@@ -75,9 +75,10 @@ module Transactions
       return if rebalance?
 
       amount_type = spending? ? :activity : :income
+      amount = spending? ? signed_amount : -signed_amount
 
       MonthlyBudgets::UpdateAmount.call(
-        amount: signed_amount,
+        amount: amount,
         amount_type: amount_type,
         month: month,
         monthly_budget: monthly_budget,

--- a/lib/dev/reset_db.rb
+++ b/lib/dev/reset_db.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ResetDb
+  # rubocop:disable Metrics/MethodLength
+  def self.call(force: false)
+    if force
+      Transaction.destroy_all
+      Payee.destroy_all
+      Account::Base.destroy_all
+    else
+      starting_payees = { name: ['Starting balance', 'Saldo inicial'] }
+      Transaction.where(payee_id: nil).destroy_all
+      Transaction.joins(:payee).where.not(payees: starting_payees).destroy_all
+      Payee.where.not(starting_payees).destroy_all
+    end
+
+    MonthlyBudget.destroy_all
+    Month.destroy_all
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/spec/factories/monthly_budgets.rb
+++ b/spec/factories/monthly_budgets.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :monthly_budget do
-    activity { rand(100_000) }
+    activity { Faker::Number.within(range: -1_000_00..0) }
     budgeted { rand(100_000) }
     category
     month

--- a/spec/factories/months.rb
+++ b/spec/factories/months.rb
@@ -5,10 +5,10 @@ FactoryBot.define do
     iso_month do
       IsoMonth.of(Faker::Date.between(from: 2.years.ago, to: Date.today))
     end
-    activity { rand(100_000) }
-    budgeted { rand(100_000) }
+    activity { Faker::Number.within(range: -1_000_00..0) }
+    budgeted { rand(1_000_00) }
     budget
-    income { rand(100_000) }
-    to_be_budgeted { rand(10_000) }
+    income { rand(1_000_00) }
+    to_be_budgeted { rand(100_00) }
   end
 end

--- a/spec/models/month_spec.rb
+++ b/spec/models/month_spec.rb
@@ -14,5 +14,23 @@ describe Month do
     it { is_expected.to validate_presence_of(:budgeted) }
     it { is_expected.to validate_presence_of(:activity) }
     it { is_expected.to validate_presence_of(:to_be_budgeted) }
+
+    it 'validates activity is at most zero' do
+      expect(build(:month, activity: 10_00)).not_to be_valid
+      expect(build(:month, activity: 0)).to be_valid
+      expect(build(:month, activity: -10_00)).to be_valid
+    end
+
+    it 'validates income is at least zero' do
+      expect(build(:month, income: 10_00)).to be_valid
+      expect(build(:month, income: 0)).to be_valid
+      expect(build(:month, income: -10_00)).not_to be_valid
+    end
+
+    it 'validates budgeted is at least zero' do
+      expect(build(:month, budgeted: 10_00)).to be_valid
+      expect(build(:month, budgeted: 0)).to be_valid
+      expect(build(:month, budgeted: -10_00)).not_to be_valid
+    end
   end
 end

--- a/spec/models/monthly_budget_spec.rb
+++ b/spec/models/monthly_budget_spec.rb
@@ -9,6 +9,20 @@ describe MonthlyBudget do
     it { is_expected.to have_many(:transactions) }
   end
 
+  describe 'validations' do
+    it 'validates activity is at most zero' do
+      expect(build(:monthly_budget, activity: 10_00)).not_to be_valid
+      expect(build(:monthly_budget, activity: 0)).to be_valid
+      expect(build(:monthly_budget, activity: -10_00)).to be_valid
+    end
+
+    it 'validates budgeted is at least zero' do
+      expect(build(:monthly_budget, budgeted: 10_00)).to be_valid
+      expect(build(:monthly_budget, budgeted: 0)).to be_valid
+      expect(build(:monthly_budget, budgeted: -10_00)).not_to be_valid
+    end
+  end
+
   describe '#available' do
     it 'is the sum between budgeted and activity', :aggregate_failures do
       expect(

--- a/spec/use_cases/transactions/create_transfer_spec.rb
+++ b/spec/use_cases/transactions/create_transfer_spec.rb
@@ -62,9 +62,9 @@ describe Transactions::CreateTransfer do
   it 'updates destination account balance' do
     expect do
       described_class.call(params)
-    end.to change {
-             destination_account.reload.cleared_balance
-           }.by(params[:amount])
+    end.to(
+      change { destination_account.reload.cleared_balance }.by(params[:amount]),
+    )
   end
 
   it 'does not change monthly budgets for :rebalance transfers' do
@@ -87,7 +87,7 @@ describe Transactions::CreateTransfer do
 
       expect(MonthlyBudgets::UpdateAmount).to have_received(:call).with(
         hash_including(
-          amount: -params[:amount],
+          amount: params[:amount],
           amount_type: :income,
         ),
       )

--- a/spec/use_cases/transactions/update_transfer_spec.rb
+++ b/spec/use_cases/transactions/update_transfer_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Transactions::UpdateTransfer do
+  let(:budget) { create(:budget) }
+  let(:category) { create(:category, :with_budget, budget: budget) }
+  let(:transfer_type) { :rebalance }
+  let(:old_reference) { DateTime.new(2022, 2, 5).iso8601 }
+  let(:new_reference) { DateTime.new(2022, 2, 10).iso8601 }
+  let(:month) do
+    create(:month,
+           iso_month: IsoMonth.of(new_reference),
+           budget: budget,
+           income: 100_00,
+           activity: -60_00,
+           budgeted: 50_00,
+           to_be_budgeted: 50_00)
+  end
+  let(:monthly_budget) do
+    create(:monthly_budget, month: month, category: category)
+  end
+  let(:origin_account) do
+    create(:checking_account, cleared_balance: 10_00)
+  end
+  let(:destination_account) do
+    create(:checking_account, cleared_balance: 80_00)
+  end
+  let(:origin_transaction) do
+    create(:transaction,
+           amount: -50_00,
+           reference_at: old_reference,
+           monthly_budget: monthly_budget,
+           month: month,
+           account: origin_account)
+  end
+  let(:destination_transaction) do
+    create(:transaction,
+           amount: 50_00,
+           reference_at: old_reference,
+           monthly_budget: monthly_budget,
+           month: month,
+           account: destination_account)
+  end
+  let(:params) do
+    {
+      amount: 20_00,
+      budget_id: budget.id,
+      category_id: category.id,
+      cleared_at: Time.current.iso8601,
+      destination_id: destination_account.id,
+      destination_transaction_id: destination_transaction.id,
+      memo: Faker::Lorem.sentence,
+      origin_id: origin_account.id,
+      origin_transaction_id: origin_transaction.id,
+      outflow: true,
+      type: transfer_type,
+      reference_at: new_reference,
+    }
+  end
+
+  before do
+    freeze_time
+
+    origin_transaction.update(linked_transaction: destination_transaction)
+    destination_transaction.update(linked_transaction: origin_transaction)
+
+    allow(MonthlyBudgets::UpdateAmount).to receive(:call).and_call_original
+  end
+
+  after { travel_back }
+
+  it 'updates outbound transaction' do
+    described_class.call(params)
+
+    expect(origin_transaction.reload).to have_attributes(
+      amount: -20_00,
+      outflow: true,
+      reference_at: DateTime.parse(new_reference),
+    )
+  end
+
+  it 'updates inbound transaction' do
+    described_class.call(params)
+
+    expect(destination_transaction.reload).to have_attributes(
+      amount: 20_00,
+      outflow: false,
+      reference_at: DateTime.parse(new_reference),
+    )
+  end
+
+  it 'updates accounts balance' do
+    described_class.call(params)
+
+    expect(origin_account.reload.cleared_balance).to eq(40_00)
+    expect(destination_account.reload.cleared_balance).to eq(50_00)
+  end
+
+  it 'does not change monthly budgets for :rebalance transfers' do
+    allow(MonthlyBudgets::UpdateAmount).to receive(:call)
+
+    described_class.call(params)
+
+    expect(MonthlyBudgets::UpdateAmount).not_to have_received(:call)
+  end
+
+  context 'when reference changes to a new month' do
+    let(:new_reference) { DateTime.new(2022, 3, 10).iso8601 }
+    let(:month) { create(:month, iso_month: '2022-02') }
+
+    it 'creates a new month if that' do
+      expect do
+        described_class.call(params)
+      end.to change { Month.where(iso_month: '2022-03').count }.by(1)
+    end
+  end
+
+  context 'when transfer is :income' do
+    let(:origin_account) do
+      create(:asset_account, cleared_balance: 10_00)
+    end
+    let(:destination_account) do
+      create(:checking_account, cleared_balance: 80_00)
+    end
+    let(:monthly_budget) { nil }
+    let(:transfer_type) { :income }
+
+    it "updates month's attributes" do
+      described_class.call(params)
+
+      expect(month.reload).to have_attributes(
+        income: 70_00,
+        to_be_budgeted: 20_00,
+      )
+    end
+
+    it "updates accounts' balance" do
+      described_class.call(params)
+
+      expect(origin_account.reload.cleared_balance).to eq(40_00)
+      expect(destination_account.reload.cleared_balance).to eq(50_00)
+    end
+
+    it 'does not update monthly budget' do
+      described_class.call(params)
+
+      category = MonthlyBudget.find_by(category_id: params[:category_id])
+
+      expect(category).to be_nil
+    end
+  end
+
+  context 'when transfer is a :spending' do
+    let(:origin_account) do
+      create(:checking_account, cleared_balance: 10_00)
+    end
+    let(:destination_account) do
+      create(:asset_account, cleared_balance: 80_00)
+    end
+    let(:monthly_budget) do
+      create(:monthly_budget,
+             month: month,
+             category: category,
+             activity: -50_00,
+             budgeted: 50_00)
+    end
+    let(:transfer_type) { :spending }
+
+    it "updates month's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { month.reload.activity }.from(-60_00).to(-30_00)
+    end
+
+    it "updates monthly budget's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { monthly_budget.reload.activity }.from(-50_00).to(-20_00)
+    end
+  end
+end


### PR DESCRIPTION
🐛 **FIXES**
- Add validation to months and monthly budgets, to make sure that `activity <= 0`, `budgeted >= 0` and `income >= 0`
- Adjust factories to use correct signed amounts

🧹 **HOUSEKEEPING**
- Add a helper `ResetDb` class