### PR TITLE
Fix broken specs that rely on auth

### DIFF
--- a/.github/workflows/budget-pipe.yml
+++ b/.github/workflows/budget-pipe.yml
@@ -31,8 +31,7 @@ jobs:
     env:
       RAILS_ENV: test
       PGHOST: localhost
-      DB_USERNAME: test
-      DB_PASSWORD: test
+      DATABASE_URL: "postgres://test:test@localhost:5432"
   rubocop:
     runs-on: ubuntu-latest
     steps:

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'uri'
 
@@ -5,9 +7,9 @@ class JsonWebToken
   def self.verify(token)
     options = {
       algorithms: 'RS256',
-      iss: self.auth0_domain,
+      iss: auth0_domain,
       verify_iss: true,
-      aud: self.auth0_audience,
+      aud: auth0_audience,
       verify_aud: true,
     }
 
@@ -17,28 +19,22 @@ class JsonWebToken
   end
 
   def self.jwks_hash
-    jwks_raw = Net::HTTP.get(URI("#{self.auth0_domain}.well-known/jwks.json"))
+    jwks_raw = Net::HTTP.get(URI("#{auth0_domain}.well-known/jwks.json"))
     jwks_keys = Array(JSON.parse(jwks_raw)['keys'])
-    Hash[
-      jwks_keys
-        .map do |k|
-          [
-            k['kid'],
-            OpenSSL::X509::Certificate.new(
-              Base64.decode64(k['x5c'].first)
-            ).public_key
-          ]
-        end
-    ]
+    jwks_keys.to_h { |k| [k['kid'], public_key(k)] }
   end
 
-  private
+  def self.public_key(key)
+    OpenSSL::X509::Certificate.new(
+      Base64.decode64(key['x5c'].first),
+    ).public_key
+  end
 
   def self.auth0_domain
-    ENV.fetch('AUTH0_DOMAIN')
+    ENV.fetch('AUTH0_DOMAIN', 'domain')
   end
 
   def self.auth0_audience
-    ENV.fetch('AUTH0_AUDIENCE')
+    ENV.fetch('AUTH0_AUDIENCE', 'audience')
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |i| "user_#{i}@mail.com" }
+    sequence(:auth_provider_id) { |i| "token_#{i}" }
 
     name { 'John' }
     password { 'my@pass123' }

--- a/spec/helpers/auth_helper.rb
+++ b/spec/helpers/auth_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AuthHelper
+  # FIXME: introduce a `token` param to tie a specific header to this
+  # specific user and prevent multiple calls here from bypassing auth.
+  def mock_auth!(user)
+    allow(JsonWebToken).to(
+      receive(:verify)
+        .and_return([{ 'sub' => user.auth_provider_id }]),
+    )
+  end
+end

--- a/spec/requests/accounts_request_spec.rb
+++ b/spec/requests/accounts_request_spec.rb
@@ -5,13 +5,18 @@ require 'rails_helper'
 describe Api::AccountsController do
   let(:budget) { create(:budget) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'GET /api/budgets/:id/accounts/' do
     context 'when there is no authorization' do
       it 'returns :unauthorized' do
-        get '/api/budgets/:id/accounts', headers: headers
+        get '/api/budgets/:id/accounts', headers: {
+          Accept: 'application/json',
+        }
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -21,7 +26,7 @@ describe Api::AccountsController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{other_budget.id}/accounts", headers: headers
 
@@ -34,9 +39,8 @@ describe Api::AccountsController do
       asset_account = create(:asset_account, budget: budget)
       checking_account = create(:checking_account, budget: budget)
 
+      mock_auth!(budget.user)
       allow(Api::AccountSerializer).to receive(:new)
-
-      sign_in(budget.user)
 
       get "/api/budgets/#{budget.id}/accounts", headers: headers
 
@@ -64,7 +68,7 @@ describe Api::AccountsController do
         other_budget = create(:budget)
         account = create(:random_account, budget: other_budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{other_budget.id}/accounts/#{account.id}",
             headers: headers
@@ -75,7 +79,7 @@ describe Api::AccountsController do
 
     context 'when there is no account in given budget with given id' do
       it 'returns :not_found' do
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{budget.id}/accounts/random-uuid", headers: headers
 
@@ -86,9 +90,8 @@ describe Api::AccountsController do
     it 'returns the account with the specified id', :aggregate_failures do
       account = create(:random_account, budget: budget)
 
+      mock_auth!(budget.user)
       allow(Api::AccountSerializer).to receive(:new)
-
-      sign_in(budget.user)
 
       get "/api/budgets/#{budget.id}/accounts/#{account.id}", headers: headers
 

--- a/spec/requests/budgets_request_spec.rb
+++ b/spec/requests/budgets_request_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Api::BudgetsController do
   let(:user) { create(:user) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'POST /api/budgets' do
@@ -25,7 +28,7 @@ describe Api::BudgetsController do
           date_format: 'dd.MM.YYYY',
         }
 
-        sign_in(user)
+        mock_auth!(user)
 
         expect do
           post '/api/budgets', headers: headers, params: params
@@ -52,7 +55,7 @@ describe Api::BudgetsController do
 
       allow(Api::BudgetSerializer).to receive(:new)
 
-      sign_in(user)
+      mock_auth!(user)
 
       get '/api/budgets', headers: headers
 
@@ -79,7 +82,7 @@ describe Api::BudgetsController do
 
         allow(Api::BudgetSerializer).to receive(:new)
 
-        sign_in(user)
+        mock_auth!(user)
 
         get "/api/budgets/#{budget.id}", headers: headers
 
@@ -93,7 +96,7 @@ describe Api::BudgetsController do
 
       allow(Api::BudgetSerializer).to receive(:new)
 
-      sign_in(user)
+      mock_auth!(user)
 
       get "/api/budgets/#{budget.id}", headers: headers
 

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Api::CategoryGroupsController do
   let(:budget) { create(:budget) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'POST /api/budgets/:id/categories' do
@@ -31,7 +34,7 @@ describe Api::CategoryGroupsController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         post "/api/budgets/#{other_budget.id}/categories",
              headers: headers,
@@ -42,7 +45,7 @@ describe Api::CategoryGroupsController do
     end
 
     it 'creates a new category within given budget', :aggregate_failures do
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       expect do
         post "/api/budgets/#{budget.id}/categories",
@@ -59,7 +62,7 @@ describe Api::CategoryGroupsController do
     it 'serializes back the newly created category', :aggregate_failures do
       allow(Api::CategorySerializer).to receive(:new)
 
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       post "/api/budgets/#{budget.id}/categories",
            headers: headers,
@@ -88,7 +91,7 @@ describe Api::CategoryGroupsController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{other_budget.id}/categories",
             headers: headers
@@ -108,7 +111,7 @@ describe Api::CategoryGroupsController do
 
       allow(Api::CategorySerializer).to receive(:new)
 
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       get "/api/budgets/#{budget.id}/categories", headers: headers
 

--- a/spec/requests/category_groups_request_spec.rb
+++ b/spec/requests/category_groups_request_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Api::CategoryGroupsController do
   let(:budget) { create(:budget) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'GET /api/budgets/:id/category_groups' do
@@ -24,7 +27,7 @@ describe Api::CategoryGroupsController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{other_budget.id}/category_groups",
             headers: headers
@@ -38,7 +41,7 @@ describe Api::CategoryGroupsController do
 
       allow(Api::CategoryGroupSerializer).to receive(:new)
 
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       get "/api/budgets/#{budget.id}/category_groups", headers: headers
 

--- a/spec/requests/me_request_spec.rb
+++ b/spec/requests/me_request_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 
 describe Api::MeController do
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'GET /api/me' do
@@ -18,7 +21,7 @@ describe Api::MeController do
 
     it 'returns ok', :aggregate_failures do
       user = create(:user)
-      sign_in(user)
+      mock_auth!(user)
 
       get '/api/me', headers: headers
 

--- a/spec/requests/monthly_budgets_request_spec.rb
+++ b/spec/requests/monthly_budgets_request_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Api::MonthlyBudgetsController do
   let(:budget) { create(:budget) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
   let(:params) do
     {
@@ -30,7 +33,7 @@ describe Api::MonthlyBudgetsController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         post "/api/budgets/#{other_budget.id}/monthly_budgets",
              headers: headers,
@@ -41,7 +44,7 @@ describe Api::MonthlyBudgetsController do
     end
 
     it 'creates a new monthly budget' do
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       expect do
         post "/api/budgets/#{budget.id}/monthly_budgets",
@@ -51,7 +54,7 @@ describe Api::MonthlyBudgetsController do
     end
 
     it 'serializes the newly-created monthly budget' do
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       allow(Api::MonthlyBudgetSerializer).to receive(:new)
 

--- a/spec/requests/payees_request_spec.rb
+++ b/spec/requests/payees_request_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Api::PayeesController do
   let(:budget) { create(:budget) }
   let(:headers) do
-    { Accept: 'application/json' }
+    {
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+    }
   end
 
   describe 'GET /api/budgets/:id/payees/' do
@@ -21,7 +24,7 @@ describe Api::PayeesController do
       it 'returns :unauthorized' do
         other_budget = create(:budget)
 
-        sign_in(budget.user)
+        mock_auth!(budget.user)
 
         get "/api/budgets/#{other_budget.id}/payees", headers: headers
 
@@ -36,7 +39,7 @@ describe Api::PayeesController do
 
       allow(Api::PayeeSerializer).to receive(:new)
 
-      sign_in(budget.user)
+      mock_auth!(budget.user)
 
       get "/api/budgets/#{budget.id}/payees", headers: headers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require_relative './helpers/auth_helper'
+
 RSpec.configure do |config|
+  config.include AuthHelper
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
🐛 **FIXES**
- Request specs that were failing due to new auth0 authentication
- Add a new `AuthHelper` module to help specs that would otherwise manually mock every request