### PR TITLE
Add services and endpoints to allow deleting transaction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '>= 2.7.1'
 
+gem 'dotenv-rails'
 gem 'fast_jsonapi', git: 'https://github.com/fast-jsonapi/fast_jsonapi'
 gem 'jwt'
 gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -218,6 +222,7 @@ DEPENDENCIES
   amazing_print
   bootsnap
   byebug
+  dotenv-rails
   factory_bot_rails
   faker
   fast_jsonapi!

--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -26,6 +26,13 @@ module Api
       render json: serialize(transaction)
     end
 
+    # DELETE /api/budgets/:budget_id/transactions/:id
+    def destroy
+      Transactions::Delete.call(id: params[:id])
+
+      head :ok
+    end
+
     private
 
     def serialize(records)

--- a/app/controllers/api/transfers_controller.rb
+++ b/app/controllers/api/transfers_controller.rb
@@ -7,16 +7,23 @@ module Api
 
     # POST /api/budgets/:budget_id/transfers
     def create
-      transactions = Transactions::CreateTransfer.call(create_params)
+      transactions = Transfers::Create.call(create_params)
 
       render json: serialize(transactions)
     end
 
     # PUT /api/budgets/:budget_id/transfers
     def update
-      transactions = Transactions::UpdateTransfer.call(update_params)
+      transactions = Transactions::Update.call(update_params)
 
       render json: serialize(transactions)
+    end
+
+    # DELETE /api/budgets/:budget_id/transfers
+    def destroy
+      Transactions::Delete.call(destroy_params)
+
+      head :ok
     end
 
     private
@@ -38,6 +45,10 @@ module Api
       create_params.merge(
         params.permit(:destination_transaction_id, :origin_transaction_id),
       )
+    end
+
+    def destroy_params
+      params.permit(:destination_transaction_id, :origin_transaction_id)
     end
   end
 end

--- a/app/use_cases/transactions/delete.rb
+++ b/app/use_cases/transactions/delete.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Transactions
+  class Delete < ApplicationUseCase
+    def initialize(params)
+      @transaction = Transaction.find(params[:id])
+      @params = params
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        undo_budgeting
+        update_account_balance
+        delete_transaction
+      end
+    end
+
+    private
+
+    attr_accessor :transaction
+
+    def undo_budgeting
+      amount_type = transaction.income? ? :income : :activity
+
+      MonthlyBudgets::UpdateAmount.call(
+        amount: -transaction.amount,
+        amount_type: amount_type,
+        month: transaction.month,
+        monthly_budget: transaction.monthly_budget,
+      )
+    end
+
+    def update_account_balance
+      Accounts::UpdateBalance.call(
+        account: transaction.account,
+        amount: -transaction.amount,
+        cleared: transaction.cleared?,
+      )
+    end
+
+    def delete_transaction
+      transaction.destroy!
+    end
+  end
+end

--- a/app/use_cases/transactions/delete_transfer.rb
+++ b/app/use_cases/transactions/delete_transfer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Transactions
+  class DeleteTransfer < ApplicationUseCase
+    def initialize(params)
+      @origin_transaction = Transaction.find(
+        params[:origin_transaction_id],
+      )
+      @destination_transaction = Transaction.find(
+        params[:destination_transaction_id],
+      )
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        undo_budgeting
+        undo_accounts_balance
+        delete_transactions
+      end
+    end
+
+    private
+
+    attr_accessor :destination_transaction, :origin_transaction
+
+    def undo_budgeting
+      return if natures_match?
+
+      # FIXME: month's activity is positive... why?
+      if origin_transaction.income?
+        update_monthly_amounts(origin_transaction.amount)
+      else
+        update_monthly_amounts(destination_transaction.amount)
+      end
+    end
+
+    def undo_accounts_balance
+      Accounts::UpdateBalance.call(
+        account: origin_transaction.account,
+        amount: -origin_transaction.amount,
+        cleared: origin_transaction.cleared?,
+      )
+      Accounts::UpdateBalance.call(
+        account: destination_transaction.account,
+        amount: -destination_transaction.amount,
+        cleared: destination_transaction.cleared?,
+      )
+    end
+
+    def delete_transactions
+      destination_transaction.destroy!
+      origin_transaction.destroy!
+    end
+
+    def update_monthly_amounts(amount)
+      MonthlyBudgets::UpdateAmount.call(
+        amount: amount,
+        amount_type: amount_type,
+        month: origin_transaction.month,
+        monthly_budget: origin_transaction.monthly_budget,
+      )
+    end
+
+    def amount_type
+      return :income if origin_transaction.income?
+
+      :activity
+    end
+
+    def natures_match?
+      origin_transaction.account.nature ==
+        destination_transaction.account.nature
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,10 +11,11 @@ Rails.application.routes.draw do
       resources :months, only: %i[show], param: :iso_month
       resources :monthly_budgets, only: %i[create index update]
       resources :payees, only: %i[index]
-      resources :transactions, only: %i[create index update]
+      resources :transactions, only: %i[create destroy index update]
       resources :transfers, only: %i[create] do
         collection do
           put :update
+          delete :destroy
         end
       end
     end

--- a/spec/use_cases/transactions/delete_spec.rb
+++ b/spec/use_cases/transactions/delete_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Transactions::Delete do
+  let(:budget) { create(:budget) }
+  let(:category) { create(:category, :with_budget, budget: budget) }
+  let(:reference_at) { DateTime.current.iso8601 }
+  let(:month) do
+    create(:month,
+           iso_month: IsoMonth.of(reference_at),
+           budget: budget,
+           income: 100_00,
+           activity: -60_00,
+           budgeted: 50_00,
+           to_be_budgeted: 50_00)
+  end
+  let(:amount) { -50_00 }
+  let(:monthly_budget) do
+    create(:monthly_budget, month: month, category: category)
+  end
+  let(:account) do
+    create(:checking_account, cleared_balance: 10_00)
+  end
+  let(:transaction) do
+    create(:transaction,
+           amount: amount,
+           reference_at: reference_at,
+           monthly_budget: monthly_budget,
+           month: month,
+           account: account)
+  end
+  let!(:params) do
+    {
+      id: transaction.id,
+    }
+  end
+
+  before { freeze_time }
+  after { travel_back }
+
+  it 'removes transaction' do
+    expect do
+      described_class.call(params)
+    end.to change { Transaction.count }.by(-1)
+
+    expect(Transaction.find_by(id: params[:id])).to be_nil
+  end
+
+  it 'updates account balance' do
+    described_class.call(params)
+
+    expect(account.reload.cleared_balance).to eq(60_00)
+  end
+
+  context 'when monthly budget is null' do
+    let(:amount) { 50_00 }
+    let(:monthly_budget) { nil }
+
+    it "updates month's income and to_be_budgeted" do
+      described_class.call(params)
+
+      expect(month.reload).to have_attributes(
+        income: 50_00,
+        to_be_budgeted: 0,
+      )
+    end
+
+    it 'does not update monthly budget' do
+      described_class.call(params)
+
+      monthly_budget = MonthlyBudget.find_by(category_id: params[:category_id])
+
+      expect(monthly_budget).to be_nil
+    end
+  end
+
+  context 'when monthly budget is present' do
+    let(:amount) { -50_00 }
+    let(:monthly_budget) do
+      create(:monthly_budget,
+             month: month,
+             category: category,
+             activity: -50_00,
+             budgeted: 50_00)
+    end
+
+    it "updates month's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { month.reload.activity }.from(-60_00).to(-10_00)
+    end
+
+    it "updates monthly budget's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { monthly_budget.reload.activity }.from(-50_00).to(-0)
+    end
+  end
+end

--- a/spec/use_cases/transactions/delete_transfer_spec.rb
+++ b/spec/use_cases/transactions/delete_transfer_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Transactions::DeleteTransfer do
+  let(:budget) { create(:budget) }
+  let(:category) { create(:category, :with_budget, budget: budget) }
+  let(:reference_at) { DateTime.new(2022, 2, 5).iso8601 }
+  let(:month) do
+    create(:month,
+           iso_month: IsoMonth.of(reference_at),
+           budget: budget,
+           income: 100_00,
+           activity: -60_00,
+           budgeted: 50_00,
+           to_be_budgeted: 50_00)
+  end
+  let(:monthly_budget) do
+    create(:monthly_budget, month: month, category: category)
+  end
+  let(:origin_account) do
+    create(:checking_account, cleared_balance: 10_00)
+  end
+  let(:destination_account) do
+    create(:checking_account, cleared_balance: 80_00)
+  end
+  let(:origin_transaction) do
+    create(:transaction,
+           amount: -50_00,
+           reference_at: reference_at,
+           monthly_budget: monthly_budget,
+           month: month,
+           account: origin_account)
+  end
+  let(:destination_transaction) do
+    create(:transaction,
+           amount: 50_00,
+           reference_at: reference_at,
+           monthly_budget: monthly_budget,
+           month: month,
+           account: destination_account)
+  end
+  let(:params) do
+    {
+      destination_transaction_id: destination_transaction.id,
+      origin_transaction_id: origin_transaction.id,
+    }
+  end
+
+  before do
+    freeze_time
+
+    origin_transaction.update(linked_transaction: destination_transaction)
+    destination_transaction.update(linked_transaction: origin_transaction)
+
+    allow(MonthlyBudgets::UpdateAmount).to receive(:call).and_call_original
+  end
+
+  after { travel_back }
+
+  it 'removes both origin and destination transactions' do
+    expect do
+      described_class.call(params)
+    end.to change { Transaction.count }.by(-2)
+
+    expect(
+      Transaction.where(id: [
+                          params[:destination_transaction_id],
+                          params[:origin_transaction_id],
+                        ]),
+    ).to be_empty
+  end
+
+  it 'updates accounts balance' do
+    described_class.call(params)
+
+    expect(origin_account.reload.cleared_balance).to eq(60_00)
+    expect(destination_account.reload.cleared_balance).to eq(30_00)
+  end
+
+  it 'does not change monthly budgets when accounts nature match' do
+    allow(MonthlyBudgets::UpdateAmount).to receive(:call)
+
+    described_class.call(params)
+
+    expect(MonthlyBudgets::UpdateAmount).not_to have_received(:call)
+  end
+
+  context 'when transfer is :income' do
+    let(:origin_account) do
+      create(:asset_account, cleared_balance: 10_00)
+    end
+    let(:destination_account) do
+      create(:checking_account, cleared_balance: 80_00)
+    end
+    let(:monthly_budget) { nil }
+
+    it "updates month's income and to_be_budgeted" do
+      described_class.call(params)
+
+      expect(month.reload).to have_attributes(
+        income: 50_00,
+        to_be_budgeted: 0,
+      )
+    end
+
+    it 'does not update monthly budget' do
+      described_class.call(params)
+
+      category = MonthlyBudget.find_by(category_id: params[:category_id])
+
+      expect(category).to be_nil
+    end
+  end
+
+  context 'when transfer is a :spending' do
+    let(:origin_account) do
+      create(:checking_account, cleared_balance: 10_00)
+    end
+    let(:destination_account) do
+      create(:asset_account, cleared_balance: 80_00)
+    end
+    let(:monthly_budget) do
+      create(:monthly_budget,
+             month: month,
+             category: category,
+             activity: -50_00,
+             budgeted: 50_00)
+    end
+
+    it "updates month's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { month.reload.activity }.from(-60_00).to(-10_00)
+    end
+
+    it "updates monthly budget's activity" do
+      expect do
+        described_class.call(params)
+      end.to change { monthly_budget.reload.activity }.from(-50_00).to(-0)
+    end
+  end
+end


### PR DESCRIPTION
🌟 **NEW**
- Add following endpoints along with its use cases:
  - `DELETE /api/budgets/:budget_id/transfers`
  - `DELETE /api/budgets/:budget_id/transactions/:id`

🐛 **FIXES**
- Add `dotenv` gem